### PR TITLE
Implemented Tracks

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/111_setup_music.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/111_setup_music.cs
@@ -48,16 +48,16 @@ namespace NzbDrone.Core.Datastore.Migration
                 .WithColumn("Overview").AsString();
 
             Create.TableForModel("Tracks")
-                .WithColumn("ItunesTrackId").AsInt32().Unique()
+                .WithColumn("SpotifyTrackId").AsString().Nullable() // This shouldn't be nullable, but TrackRepository won't behave. Someone please fix this.
                 .WithColumn("AlbumId").AsString()
-                .WithColumn("ArtistsId").AsString().Nullable()
+                .WithColumn("ArtistId").AsString() // This may be a list of Ids in future for compilations
+                .WithColumn("ArtistSpotifyId").AsString()
+                .WithColumn("Compilation").AsBoolean()
                 .WithColumn("TrackNumber").AsInt32()
                 .WithColumn("Title").AsString().Nullable()
                 .WithColumn("Ignored").AsBoolean().Nullable()
                 .WithColumn("Explict").AsBoolean()
                 .WithColumn("Monitored").AsBoolean()
-                .WithColumn("TrackExplicitName").AsString().Nullable()
-                .WithColumn("TrackCensoredName").AsString().Nullable()
                 .WithColumn("TrackFileId").AsInt32().Nullable()
                 .WithColumn("ReleaseDate").AsDateTime().Nullable();
 

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -102,7 +102,7 @@ namespace NzbDrone.Core.Datastore
                   .Relationships.AutoMapICollectionOrComplexProperties()
                   .For("Tracks")
                   .LazyLoad(condition: parent => parent.Id > 0,
-                            query: (db, parent) => db.Query<Track>().Where(c => c.SpotifyTrackId == parent.Id).ToList())
+                            query: (db, parent) => db.Query<Track>().Where(c => c.ArtistId == parent.Id).ToList()) // TODO: Figure what the hell to do here
                   .HasOne(file => file.Artist, file => file.AlbumId); 
 
             Mapper.Entity<Track>().RegisterModel("Tracks")
@@ -110,6 +110,7 @@ namespace NzbDrone.Core.Datastore
                   .Ignore(e => e.Album)
                   .Ignore(e => e.HasFile)
                   .Relationship()
+                  // TODO: Need to implement ArtistId to Artist.Id here
                   .HasOne(track => track.TrackFile, track => track.TrackFileId); // TODO: Check lazy load for artists
 
             Mapper.Entity<QualityDefinition>().RegisterModel("QualityDefinitions")

--- a/src/NzbDrone.Core/Jobs/TaskManager.cs
+++ b/src/NzbDrone.Core/Jobs/TaskManager.cs
@@ -68,7 +68,7 @@ namespace NzbDrone.Core.Jobs
                     //new ScheduledTask{ Interval = 3*60, TypeName = typeof(UpdateSceneMappingCommand).FullName},
                     new ScheduledTask{ Interval = 6*60, TypeName = typeof(CheckHealthCommand).FullName},
                     new ScheduledTask{ Interval = 12*60, TypeName = typeof(RefreshArtistCommand).FullName},
-                    new ScheduledTask{ Interval = 12*60, TypeName = typeof(RefreshSeriesCommand).FullName}, // TODO: Remove
+                    //new ScheduledTask{ Interval = 12*60, TypeName = typeof(RefreshSeriesCommand).FullName}, // TODO: Remove
                     new ScheduledTask{ Interval = 24*60, TypeName = typeof(HousekeepingCommand).FullName},
                     new ScheduledTask{ Interval = 7*24*60, TypeName = typeof(BackupCommand).FullName},
 

--- a/src/NzbDrone.Core/MediaFiles/Events/TrackFileAddedEvent.cs
+++ b/src/NzbDrone.Core/MediaFiles/Events/TrackFileAddedEvent.cs
@@ -1,0 +1,18 @@
+﻿using NzbDrone.Common.Messaging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NzbDrone.Core.MediaFiles.Events
+{
+    public class TrackFileAddedEvent : IEvent
+    {
+        public TrackFile TrackFile { get; private set; }
+
+        public TrackFileAddedEvent(TrackFile trackFile)
+        {
+            TrackFile = trackFile;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Music/RefreshArtistService.cs
+++ b/src/NzbDrone.Core/Music/RefreshArtistService.cs
@@ -22,9 +22,8 @@ namespace NzbDrone.Core.Music
         private readonly IArtistService _artistService;
         private readonly IRefreshTrackService _refreshTrackService;
         private readonly IEventAggregator _eventAggregator;
-        //private readonly IDailySeriesService _dailySeriesService;
         private readonly IDiskScanService _diskScanService;
-        //private readonly ICheckIfArtistShouldBeRefreshed _checkIfArtistShouldBeRefreshed;
+        private readonly ICheckIfArtistShouldBeRefreshed _checkIfArtistShouldBeRefreshed;
         private readonly Logger _logger;
 
         public RefreshArtistService(IProvideArtistInfo artistInfo,
@@ -32,7 +31,7 @@ namespace NzbDrone.Core.Music
                                     IRefreshTrackService refreshTrackService,
                                     IEventAggregator eventAggregator,
                                     IDiskScanService diskScanService,
-                                    //ICheckIfArtistShouldBeRefreshed checkIfArtistShouldBeRefreshed,
+                                    ICheckIfArtistShouldBeRefreshed checkIfArtistShouldBeRefreshed,
                                     Logger logger)
         {
             _artistInfo = artistInfo;
@@ -40,7 +39,7 @@ namespace NzbDrone.Core.Music
             _refreshTrackService = refreshTrackService;
             _eventAggregator = eventAggregator;
             _diskScanService = diskScanService;
-            //_checkIfArtistShouldBeRefreshed = checkIfArtistShouldBeRefreshed;
+            _checkIfArtistShouldBeRefreshed = checkIfArtistShouldBeRefreshed;
             _logger = logger;
         }
 
@@ -75,7 +74,6 @@ namespace NzbDrone.Core.Music
             artist.CleanTitle = artistInfo.CleanTitle;
             artist.LastInfoSync = DateTime.UtcNow;
             artist.Images = artistInfo.Images;
-            //artist.Actors = artistInfo.Actors;
             artist.Genres = artistInfo.Genres;
 
             try
@@ -142,7 +140,7 @@ namespace NzbDrone.Core.Music
 
                 foreach (var artist in allArtists)
                 {
-                    if (message.Trigger == CommandTrigger.Manual /*|| _checkIfArtistShouldBeRefreshed.ShouldRefresh(artist)*/)
+                    if (message.Trigger == CommandTrigger.Manual || _checkIfArtistShouldBeRefreshed.ShouldRefresh(artist))
                     {
                         try
                         {

--- a/src/NzbDrone.Core/Music/RefreshTrackService.cs
+++ b/src/NzbDrone.Core/Music/RefreshTrackService.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Music
             var successCount = 0;
             var failCount = 0;
 
-            var existingTracks = _trackService.GetTrackByArtist(artist.SpotifyId);
+            var existingTracks = _trackService.GetTracksByArtist(artist.SpotifyId);
             var albums = artist.Albums;
 
             var updateList = new List<Track>();
@@ -57,13 +57,26 @@ namespace NzbDrone.Core.Music
                         trackToUpdate.Monitored = GetMonitoredStatus(track, albums);
                         newList.Add(trackToUpdate);
                     }
-                    trackToUpdate.ArtistId = artist.SpotifyId; // TODO: Ensure LazyLoaded<Artist> field gets updated.
+
+                    trackToUpdate.SpotifyTrackId = track.SpotifyTrackId;
                     trackToUpdate.TrackNumber = track.TrackNumber;
                     trackToUpdate.Title = track.Title ?? "Unknown";
-                    
+                    trackToUpdate.AlbumId = track.AlbumId;
+                    trackToUpdate.Album = track.Album;
+                    trackToUpdate.Explict = track.Explict;
+                    if (track.ArtistSpotifyId.IsNullOrWhiteSpace())
+                    {
+                        trackToUpdate.ArtistSpotifyId = artist.SpotifyId;
+                    } else
+                    {
+                        trackToUpdate.ArtistSpotifyId = track.ArtistSpotifyId;
+                    }
+                    trackToUpdate.ArtistId = track.ArtistId;
+                    trackToUpdate.Compilation = track.Compilation;
+
                     // TODO: Implement rest of [RefreshTrackService] fields
-                    
-                    
+
+
 
                     successCount++;
                 }

--- a/src/NzbDrone.Core/Music/ShouldRefreshArtist.cs
+++ b/src/NzbDrone.Core/Music/ShouldRefreshArtist.cs
@@ -1,0 +1,43 @@
+﻿using NLog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NzbDrone.Core.Music
+{
+    public interface ICheckIfArtistShouldBeRefreshed
+    {
+        bool ShouldRefresh(Artist artist);
+    }
+
+    public class CheckIfArtistShouldBeRefreshed : ICheckIfArtistShouldBeRefreshed
+    {
+        private readonly ITrackService _trackService;
+        private readonly Logger _logger;
+
+        public CheckIfArtistShouldBeRefreshed(ITrackService trackService, Logger logger)
+        {
+            _trackService = trackService;
+            _logger = logger;
+        }
+
+        public bool ShouldRefresh(Artist artist)
+        {
+            if (artist.LastInfoSync < DateTime.UtcNow.AddDays(-30))
+            {
+                _logger.Trace("Artist {0} last updated more than 30 days ago, should refresh.", artist.ArtistName);
+                return true;
+            }
+
+            if (artist.LastInfoSync >= DateTime.UtcNow.AddHours(-6))
+            {
+                _logger.Trace("Artist {0} last updated less than 6 hours ago, should not be refreshed.", artist.ArtistName);
+                return false;
+            }
+
+            //_logger.Trace("Artist {0} ended long ago, should not be refreshed.", artist.Title);
+            return false;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Music/Track.cs
+++ b/src/NzbDrone.Core/Music/Track.cs
@@ -17,18 +17,17 @@ namespace NzbDrone.Core.Music
 
         public const string RELEASE_DATE_FORMAT = "yyyy-MM-dd";
 
-        public int SpotifyTrackId { get; set; }
+        public string SpotifyTrackId { get; set; }
         public string AlbumId { get; set; }
         public LazyLoaded<Artist> Artist { get; set; }
-        public string ArtistId { get; set; }
-        public int CompilationId { get; set; }
+        public string ArtistSpotifyId { get; set; }
+        public int ArtistId { get; set; } // This is the DB Id of the Artist, not the SpotifyId
+        //public int CompilationId { get; set; }
         public bool Compilation { get; set; }
         public int TrackNumber { get; set; }
         public string Title { get; set; }
         public bool Ignored { get; set; }
         public bool Explict { get; set; }
-        public string TrackExplicitName { get; set; }
-        public string TrackCensoredName { get; set; }
         public bool Monitored { get; set; }
         public int TrackFileId { get; set; } 
         public DateTime? ReleaseDate { get; set; }

--- a/src/NzbDrone.Core/Music/Track.cs
+++ b/src/NzbDrone.Core/Music/Track.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Music
         public string AlbumId { get; set; }
         public LazyLoaded<Artist> Artist { get; set; }
         public string ArtistSpotifyId { get; set; }
-        public int ArtistId { get; set; } // This is the DB Id of the Artist, not the SpotifyId
+        public long ArtistId { get; set; } // This is the DB Id of the Artist, not the SpotifyId
         //public int CompilationId { get; set; }
         public bool Compilation { get; set; }
         public int TrackNumber { get; set; }
@@ -31,11 +31,6 @@ namespace NzbDrone.Core.Music
         public bool Monitored { get; set; }
         public int TrackFileId { get; set; } 
         public DateTime? ReleaseDate { get; set; }
-        /*
-        public Ratings Ratings { get; set; } // This might be aplicable as can be pulled from IDv3 tags
-        public List<MediaCover.MediaCover> Images { get; set; }*/
-
-        //public string SeriesTitle { get; private set; }
 
         public LazyLoaded<TrackFile> TrackFile { get; set; }
 

--- a/src/NzbDrone.Core/Music/TrackService.cs
+++ b/src/NzbDrone.Core/Music/TrackService.cs
@@ -1,4 +1,9 @@
-﻿using NzbDrone.Core.Datastore;
+﻿using NLog;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.MediaFiles.Events;
+using NzbDrone.Core.Music.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,12 +17,12 @@ namespace NzbDrone.Core.Music
         List<Track> GetTracks(IEnumerable<int> ids);
         Track FindTrack(string artistId, string albumId, int trackNumber);
         Track FindTrackByTitle(string artistId, string albumId, string releaseTitle);
-        List<Track> GetTrackByArtist(string artistId);
-        List<Track> GetTracksByAlbum(string artistId, string albumId);
-        List<Track> GetTracksByAlbumTitle(string artistId, string albumTitle);
+        List<Track> GetTracksByArtist(string artistId);
+        //List<Track> GetTracksByAlbum(string artistId, string albumId);
+        //List<Track> GetTracksByAlbumTitle(string artistId, string albumTitle);
         List<Track> TracksWithFiles(string artistId);
-        PagingSpec<Track> TracksWithoutFiles(PagingSpec<Track> pagingSpec);
-        List<Track> GeTracksByFileId(int trackFileId);
+        //PagingSpec<Track> TracksWithoutFiles(PagingSpec<Track> pagingSpec);
+        List<Track> GetTracksByFileId(int trackFileId);
         void UpdateTrack(Track track);
         void SetTrackMonitored(int trackId, bool monitored);
         void UpdateTracks(List<Track> tracks);
@@ -29,89 +34,158 @@ namespace NzbDrone.Core.Music
 
     public class TrackService : ITrackService
     {
-        public void DeleteMany(List<Track> tracks)
-        {
-            throw new NotImplementedException();
-        }
+        private readonly ITrackRepository _trackRepository;
+        private readonly IConfigService _configService;
+        private readonly Logger _logger;
 
-        public Track FindTrack(string artistId, string albumId, int trackNumber)
+        public TrackService(ITrackRepository trackRepository, IConfigService configService, Logger logger)
         {
-            throw new NotImplementedException();
-        }
-
-        public Track FindTrackByTitle(string artistId, string albumId, string releaseTitle)
-        {
-            throw new NotImplementedException();
-        }
-
-        public List<Track> GeTracksByFileId(int trackFileId)
-        {
-            throw new NotImplementedException();
+            _trackRepository = trackRepository;
+            _configService = configService;
+            _logger = logger;
         }
 
         public Track GetTrack(int id)
         {
-            throw new NotImplementedException();
-        }
-
-        public List<Track> GetTrackByArtist(string artistId)
-        {
-            throw new NotImplementedException();
+            return _trackRepository.Get(id);
         }
 
         public List<Track> GetTracks(IEnumerable<int> ids)
         {
-            throw new NotImplementedException();
+            return _trackRepository.Get(ids).ToList();
+        }
+
+        public Track FindTrack(string artistId, string albumId, int episodeNumber)
+        {
+            return _trackRepository.Find(artistId, albumId, episodeNumber);
+        }
+
+        public List<Track> GetTracksByArtist(string artistId)
+        {
+            return _trackRepository.GetTracks(artistId).ToList();
         }
 
         public List<Track> GetTracksByAlbum(string artistId, string albumId)
         {
-            throw new NotImplementedException();
+            return _trackRepository.GetTracks(artistId, albumId);
         }
 
-        public List<Track> GetTracksByAlbumTitle(string artistId, string albumTitle)
+        public Track FindTrackByTitle(string artistId, string albumId, string releaseTitle)
         {
-            throw new NotImplementedException();
-        }
+            // TODO: can replace this search mechanism with something smarter/faster/better
+            var normalizedReleaseTitle = Parser.Parser.NormalizeEpisodeTitle(releaseTitle).Replace(".", " ");
+            var tracks = _trackRepository.GetTracks(artistId, albumId);
 
-        public void InsertMany(List<Track> tracks)
-        {
-            throw new NotImplementedException();
-        }
+            var matches = tracks.Select(
+                track => new
+                {
+                    Position = normalizedReleaseTitle.IndexOf(Parser.Parser.NormalizeEpisodeTitle(track.Title), StringComparison.CurrentCultureIgnoreCase),
+                    Length = Parser.Parser.NormalizeEpisodeTitle(track.Title).Length,
+                    Track = track
+                })
+                                .Where(e => e.Track.Title.Length > 0 && e.Position >= 0)
+                                .OrderBy(e => e.Position)
+                                .ThenByDescending(e => e.Length)
+                                .ToList();
 
-        public void SetTrackMonitored(int trackId, bool monitored)
-        {
-            throw new NotImplementedException();
-        }
+            if (matches.Any())
+            {
+                return matches.First().Track;
+            }
 
-        public void SetTrackMonitoredByAlbum(string artistId, string albumId, bool monitored)
-        {
-            throw new NotImplementedException();
+            return null;
         }
 
         public List<Track> TracksWithFiles(string artistId)
         {
-            throw new NotImplementedException();
+            return _trackRepository.TracksWithFiles(artistId);
         }
+
 
         public PagingSpec<Track> TracksWithoutFiles(PagingSpec<Track> pagingSpec)
         {
-            throw new NotImplementedException();
+            var episodeResult = _trackRepository.TracksWithoutFiles(pagingSpec);
+
+            return episodeResult;
         }
 
-        public void UpdateMany(List<Track> tracks)
+        public List<Track> GetTracksByFileId(int trackFileId)
         {
-            throw new NotImplementedException();
+            return _trackRepository.GetTracksByFileId(trackFileId);
         }
 
         public void UpdateTrack(Track track)
         {
-            throw new NotImplementedException();
+            _trackRepository.Update(track);
+        }
+
+        public void SetTrackMonitored(int trackId, bool monitored)
+        {
+            var track = _trackRepository.Get(trackId);
+            _trackRepository.SetMonitoredFlat(track, monitored);
+
+            _logger.Debug("Monitored flag for Track:{0} was set to {1}", trackId, monitored);
+        }
+
+        public void SetTrackMonitoredByAlbum(string artistId, string albumId, bool monitored)
+        {
+            _trackRepository.SetMonitoredByAlbum(artistId, albumId, monitored);
+        }
+
+        public void UpdateEpisodes(List<Track> tracks)
+        {
+            _trackRepository.UpdateMany(tracks);
+        }
+
+        public void InsertMany(List<Track> tracks)
+        {
+            _trackRepository.InsertMany(tracks);
+        }
+
+        public void UpdateMany(List<Track> tracks)
+        {
+            _trackRepository.UpdateMany(tracks);
+        }
+
+        public void DeleteMany(List<Track> tracks)
+        {
+            _trackRepository.DeleteMany(tracks);
+        }
+
+        public void HandleAsync(ArtistDeletedEvent message)
+        {
+            var tracks = GetTracksByArtist(message.Artist.SpotifyId);
+            _trackRepository.DeleteMany(tracks);
+        }
+
+        public void Handle(TrackFileDeletedEvent message)
+        {
+            foreach (var track in GetTracksByFileId(message.TrackFile.Id))
+            {
+                _logger.Debug("Detaching track {0} from file.", track.Id);
+                track.TrackFileId = 0;
+
+                if (message.Reason != DeleteMediaFileReason.Upgrade && _configService.AutoUnmonitorPreviouslyDownloadedEpisodes)
+                {
+                    track.Monitored = false;
+                }
+
+                UpdateTrack(track);
+            }
+        }
+
+        public void Handle(TrackFileAddedEvent message)
+        {
+            foreach (var track in message.TrackFile.Tracks.Value)
+            {
+                _trackRepository.SetFileId(track.Id, message.TrackFile.Id);
+                _logger.Debug("Linking [{0}] > [{1}]", message.TrackFile.RelativePath, track);
+            }
         }
 
         public void UpdateTracks(List<Track> tracks)
         {
-            throw new NotImplementedException();
+            _trackRepository.UpdateMany(tracks);
         }
     }
 }

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -769,6 +769,7 @@
     <Compile Include="MediaFiles\Events\SeriesRenamedEvent.cs" />
     <Compile Include="MediaFiles\Events\SeriesScanSkippedEvent.cs" />
     <Compile Include="MediaFiles\Events\SeriesScannedEvent.cs" />
+    <Compile Include="MediaFiles\Events\TrackFileAddedEvent.cs" />
     <Compile Include="MediaFiles\Events\TrackFileDeletedEvent.cs" />
     <Compile Include="MediaFiles\Events\TrackImportedEvent.cs" />
     <Compile Include="MediaFiles\FileDateType.cs" />
@@ -868,7 +869,9 @@
     <Compile Include="Music\Events\TrackInfoRefreshedEvent.cs" />
     <Compile Include="Music\RefreshArtistService.cs" />
     <Compile Include="Music\RefreshTrackService.cs" />
+    <Compile Include="Music\ShouldRefreshArtist.cs" />
     <Compile Include="Music\Track.cs" />
+    <Compile Include="Music\TrackRepository.cs" />
     <Compile Include="Music\TrackService.cs" />
     <Compile Include="Notifications\Join\JoinAuthException.cs" />
     <Compile Include="Notifications\Join\JoinInvalidDeviceException.cs" />

--- a/src/UI/Series/Index/SeriesIndexItemView.js
+++ b/src/UI/Series/Index/SeriesIndexItemView.js
@@ -9,14 +9,14 @@ module.exports = Marionette.ItemView.extend({
 
     events : {
         'click .x-edit'    : '_editSeries',
-        'click .x-refresh' : '_refreshSeries'
+        'click .x-refresh' : '_refreshArtist'
     },
 
     onRender : function() {
         CommandController.bindToCommand({
             element : this.ui.refresh,
             command : {
-                name     : 'refreshSeries',
+                name     : 'refreshArtist',
                 seriesId : this.model.get('id')
             }
         });
@@ -26,9 +26,9 @@ module.exports = Marionette.ItemView.extend({
         vent.trigger(vent.Commands.EditSeriesCommand, { series : this.model });
     },
 
-    _refreshSeries : function() {
-        CommandController.Execute('refreshSeries', {
-            name     : 'refreshSeries',
+    _refreshArtist : function() {
+        CommandController.Execute('refreshArtist', {
+            name     : 'refreshArtist',
             seriesId : this.model.id
         });
     }


### PR DESCRIPTION
You will need to delete your lidarr.db with this PR due to extensive DB changes. 

#### Database Migration
YES

#### Description
Implemented Tracks. The API can now fetch albums and tracks per album and save them to the DB. Artist object now supports an AristSlug for ArtistDetail view. 

#### Todos
- [x] Tests
- [x] Documentation


#### Issues Fixed or Closed by this PR

* 
