### PR TITLE
Updated build.sh to work on linux without X11

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -153,9 +153,9 @@ PackageMono()
     echo "Adding CurlSharp.dll.config (for dllmap)"
     cp $sourceFolder/NzbDrone.Common/CurlSharp.dll.config $outputFolderMono
 
-    echo "Renaming NzbDrone.Console.exe to NzbDrone.exe"
-    rm $outputFolderMono/NzbDrone.exe*
-    for file in $outputFolderMono/NzbDrone.Console.exe*; do
+    echo "Renaming Lidarr.Console.exe to Lidarr.exe"
+    rm $outputFolderMono/Lidarr.exe*
+    for file in $outputFolderMono/Lidarr.Console.exe*; do
         mv "$file" "${file//.Console/}"
     done
 


### PR DESCRIPTION
Updated the build.sh script to refer to Lidarr.exe instead of NzbDrone.exe, to prevent linking in SysTrayApp.cs on linux, which makes Lidarr.exe require an active X11 display to run.